### PR TITLE
feat: make both version and name optional for multi-output

### DIFF
--- a/examples/zlib/recipe.yaml
+++ b/examples/zlib/recipe.yaml
@@ -4,7 +4,7 @@ context:
   version: 1.2.13
   build_number: 5
 
-package:
+recipe:
   name: zlib-split
   version: ${{version}}
 

--- a/examples/zlib/recipe.yaml
+++ b/examples/zlib/recipe.yaml
@@ -1,0 +1,104 @@
+# yaml-language-server: $schema=../../schema.json
+
+context:
+  version: 1.2.13
+  build_number: 5
+
+package:
+  name: zlib-split
+  version: ${{version}}
+
+source:
+  url: http://zlib.net/zlib-${{ version }}.tar.gz
+  sha256: b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30
+
+outputs:
+  - package:
+      name: libzlib
+    build:
+      run_exports:
+        - ${{ pin_subpackage('libzlib', max_pin='x.x') }}
+      script:
+        - echo "build libzlib"
+    requirements:
+      build:
+        - ${{ compiler('c') }}
+      host:
+      run:
+      run_constrained:
+        - zlib ${{ version }} *_${{ build_num }}
+
+    test:
+      - script:
+        - if: unix
+          then:
+          - test ! -f ${PREFIX}/lib/libz.a            
+          - test ! -f ${PREFIX}/lib/libz${SHLIB_EXT}  
+          - test ! -f ${PREFIX}/include/zlib.h        
+        - if: win
+          then:
+          - if not exist %LIBRARY_BIN%\zlib.dll exit 1 
+          - if not exist %PREFIX%\zlib.dll exit 1 
+
+  - package:
+      name: libzlib-wapi
+    build:
+      skip: 
+        - not win
+      run_exports:
+        - ${{ pin_subpackage('libzlib-wapi', max_pin='x.x') }}
+    requirements:
+      build:
+        - ${{ compiler('c') }}
+      host:
+      run:
+      run_constrained:
+        - zlib ${{ version }} *_${{ build_num }}
+        - zlib-wapi ${{ version }} *_${{ build_num }}
+    files:
+      - Library/bin/zlibwapi.dll   # [win]
+    test:
+      - script:
+        - if not exist "%LIBRARY_BIN%\zlibwapi.dll" exit 1
+
+  - package:
+      name: zlib
+    build:
+      run_exports:
+        - ${{ pin_subpackage('libzlib', max_pin='x.x') }}
+      script:
+        - echo "build zlib"
+    requirements:
+      build:
+        - ${{ compiler('c') }}
+      host:
+        - ${{ pin_subpackage('libzlib', exact=True) }}
+      run:
+        - ${{ pin_subpackage('libzlib', exact=True) }}
+
+    test:
+      - extra_requirements: 
+          build:
+            - ${{ compiler('c') }}
+        files:
+          recipe:
+            - test_compile_flags.bat
+            - test_compile_flags.c
+        script:
+          - test -f ${PREFIX}/lib/libz.a
+
+about:
+  homepage: http://zlib.net/
+  # http://zlib.net/zlib_license.html
+  license: Zlib
+  summary: Massively spiffy yet delicately unobtrusive compression library
+  license_file: license.txt
+  description: |
+    zlib is designed to be a free, general-purpose, lossless data-compression
+    library for use on virtually any computer hardware and operating system.
+  repository: https://github.com/madler/zlib
+
+extra:
+  recipe-maintainers:
+    - github_name
+  feedstock-name: zlib

--- a/model.py
+++ b/model.py
@@ -38,16 +38,14 @@ class IfStatement(BaseModel, Generic[T]):
 ###################
 
 
-class BasePackage(StrictBaseModel):
+class SimplePackage(StrictBaseModel):
     name: str = Field(description="The package name")
-
-
-class SimplePackage(BasePackage):
     version: str = Field(description="The package version")
 
 
-class ComplexPackage(BasePackage):
-    pass
+class ComplexPackage(StrictBaseModel):
+    name: Optional[str] = Field(None, description="The package name, this can be overwritten per output")
+    version: Optional[str] = Field(None, description="The package version, this can be overwritten per output")
 
 
 ###################
@@ -428,8 +426,8 @@ class OutputBuild(Build):
 
 
 class Output(BaseModel):
-    package: Optional[SimplePackage] = Field(
-        None, description="The package name and version."
+    package: Optional[ComplexPackage] = Field(
+        None, description="The package name and version, this overwrites any top-level fields."
     )
 
     source: Optional[ConditionalList[Source]] = Field(

--- a/model.py
+++ b/model.py
@@ -44,8 +44,8 @@ class SimplePackage(StrictBaseModel):
 
 
 class ComplexPackage(StrictBaseModel):
-    name: Optional[str] = Field(None, description="The package name, this can be overwritten per output")
-    version: Optional[str] = Field(None, description="The package version, this can be overwritten per output")
+    name: str = Field(description="The recipe name, this is only used to identify the name of the recipe.")
+    version: Optional[str] = Field(None, description="The version of each output, this can be overwritten per output")
 
 
 ###################
@@ -491,7 +491,7 @@ class BaseRecipe(StrictBaseModel):
 
 
 class ComplexRecipe(BaseRecipe):
-    package: Optional[ComplexPackage] = Field(None, description="The package version.")
+    recipe: Optional[ComplexPackage] = Field(None, description="The package version.")
 
     outputs: ConditionalList[Output] = Field(
         ..., description="A list of outputs that are generated for this recipe."

--- a/schema.json
+++ b/schema.json
@@ -944,17 +944,9 @@
       "additionalProperties": false,
       "properties": {
         "name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The package name, this can be overwritten per output",
-          "title": "Name"
+          "description": "The recipe name, this is only used to identify the name of the recipe.",
+          "title": "Name",
+          "type": "string"
         },
         "version": {
           "anyOf": [
@@ -966,10 +958,13 @@
             }
           ],
           "default": null,
-          "description": "The package version, this can be overwritten per output",
+          "description": "The version of each output, this can be overwritten per output",
           "title": "Version"
         }
       },
+      "required": [
+        "name"
+      ],
       "title": "ComplexPackage",
       "type": "object"
     },
@@ -1067,7 +1062,7 @@
           "description": "An set of arbitrary values that are included in the package manifest",
           "title": "Extra"
         },
-        "package": {
+        "recipe": {
           "anyOf": [
             {
               "$ref": "#/$defs/ComplexPackage"

--- a/schema.json
+++ b/schema.json
@@ -944,14 +944,32 @@
       "additionalProperties": false,
       "properties": {
         "name": {
-          "description": "The package name",
-          "title": "Name",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The package name, this can be overwritten per output",
+          "title": "Name"
+        },
+        "version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The package version, this can be overwritten per output",
+          "title": "Version"
         }
       },
-      "required": [
-        "name"
-      ],
       "title": "ComplexPackage",
       "type": "object"
     },
@@ -1491,14 +1509,14 @@
         "package": {
           "anyOf": [
             {
-              "$ref": "#/$defs/SimplePackage"
+              "$ref": "#/$defs/ComplexPackage"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The package name and version."
+          "description": "The package name and version, this overwrites any top-level fields."
         },
         "source": {
           "anyOf": [


### PR DESCRIPTION
Make the `name` and `version` field optional when specifying multi-output. It is left up to the builder to ensure there is a valid version and name for each output. Im not entirely sure how we can capture that in pydantic/json schema.