### PR TITLE
fix: align test section with CEP & rattler-build

### DIFF
--- a/examples/mamba/recipe.yaml
+++ b/examples/mamba/recipe.yaml
@@ -119,10 +119,12 @@ outputs:
         from_package: 
         - spdlog
 
-    test:
-      - imports:
-          - libmambapy
-          - libmambapy.bindings
+    tests:
+      - python:
+          imports:
+            - libmambapy
+            - libmambapy.bindings
+          pip_check: true
       - script:
           - python -c "import libmambapy._version; assert libmambapy._version.__version__ == '${{ libmambapy_version }}'"
 
@@ -151,10 +153,11 @@ outputs:
         - conda >=4.14,<23.4
         - ${{ pin_subpackage('libmambapy', exact=True) }}
 
-    test:
-      - imports: [mamba]
+    tests:
+      - python:
+          imports: [mamba]
 
-      - extra_requirements:
+      - requirements:
           run:
             - pip
         script:

--- a/examples/xtensor/recipe.yaml
+++ b/examples/xtensor/recipe.yaml
@@ -31,7 +31,7 @@ requirements:
   run_constraints:
     - xsimd >=8.0.3,<10
 
-test:
+tests:
   - script:
       - if: unix
         then:

--- a/model.py
+++ b/model.py
@@ -400,11 +400,11 @@ class TestElementFiles(StrictBaseModel):
     )
 
 
-class CommandTestElement(StrictBaseModel):
-    script: ConditionalList[NonEmptyStr] = Field(
+class ScriptTestElement(StrictBaseModel):
+    script: str | Script | ConditionalList[NonEmptyStr] = Field(
         None, description="A script to run to perform the test."
     )
-    extra_requirements: TestElementRequires | None = Field(
+    requirements: TestElementRequires | None = Field(
         None, description="Additional dependencies to install before running the test."
     )
     files: TestElementFiles | None = Field(
@@ -434,7 +434,7 @@ class DownstreamTestElement(StrictBaseModel):
     )
 
 
-TestElement = CommandTestElement | PythonTestElement | DownstreamTestElement
+TestElement = ScriptTestElement | PythonTestElement | DownstreamTestElement
 
 #########
 # About #
@@ -563,7 +563,7 @@ class ComplexRecipe(BaseRecipe):
 class SimpleRecipe(BaseRecipe):
     package: SimplePackage = Field(..., description="The package name and version.")
 
-    test: ConditionalList[TestElement] | None = Field(
+    tests: ConditionalList[TestElement] | None = Field(
         None, description="Tests to run after packaging"
     )
 

--- a/schema.json
+++ b/schema.json
@@ -451,65 +451,6 @@
       "title": "Build",
       "type": "object"
     },
-    "CommandTestElement": {
-      "additionalProperties": false,
-      "properties": {
-        "script": {
-          "anyOf": [
-            {
-              "minLength": 1,
-              "type": "string"
-            },
-            {
-              "$ref": "#/$defs/IfStatement"
-            },
-            {
-              "items": {
-                "anyOf": [
-                  {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/$defs/IfStatement"
-                  }
-                ]
-              },
-              "type": "array"
-            }
-          ],
-          "default": null,
-          "description": "A script to run to perform the test.",
-          "title": "Script"
-        },
-        "extra_requirements": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TestElementRequires"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Additional dependencies to install before running the test."
-        },
-        "files": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TestElementFiles"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Additional files to include for the test."
-        }
-      },
-      "title": "CommandTestElement",
-      "type": "object"
-    },
     "ComplexPackage": {
       "additionalProperties": false,
       "properties": {
@@ -1211,7 +1152,7 @@
       "title": "IfStatement",
       "type": "object"
     },
-    "IfStatement_Union_CommandTestElement__PythonTestElement__DownstreamTestElement__": {
+    "IfStatement_Union_ScriptTestElement__PythonTestElement__DownstreamTestElement__": {
       "properties": {
         "if": {
           "title": "If",
@@ -1220,7 +1161,7 @@
         "then": {
           "anyOf": [
             {
-              "$ref": "#/$defs/CommandTestElement"
+              "$ref": "#/$defs/ScriptTestElement"
             },
             {
               "$ref": "#/$defs/PythonTestElement"
@@ -1232,7 +1173,7 @@
               "items": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/CommandTestElement"
+                    "$ref": "#/$defs/ScriptTestElement"
                   },
                   {
                     "$ref": "#/$defs/PythonTestElement"
@@ -1250,7 +1191,7 @@
         "else": {
           "anyOf": [
             {
-              "$ref": "#/$defs/CommandTestElement"
+              "$ref": "#/$defs/ScriptTestElement"
             },
             {
               "$ref": "#/$defs/PythonTestElement"
@@ -1262,7 +1203,7 @@
               "items": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/CommandTestElement"
+                    "$ref": "#/$defs/ScriptTestElement"
                   },
                   {
                     "$ref": "#/$defs/PythonTestElement"
@@ -1286,7 +1227,7 @@
         "if",
         "then"
       ],
-      "title": "IfStatement[Union[CommandTestElement, PythonTestElement, DownstreamTestElement]]",
+      "title": "IfStatement[Union[ScriptTestElement, PythonTestElement, DownstreamTestElement]]",
       "type": "object"
     },
     "IfStatement_Union_UrlSource__GitRev__GitTag__GitBranch__BaseGitSource__LocalSource__": {
@@ -1723,7 +1664,7 @@
               "items": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/CommandTestElement"
+                    "$ref": "#/$defs/ScriptTestElement"
                   },
                   {
                     "$ref": "#/$defs/PythonTestElement"
@@ -1732,13 +1673,13 @@
                     "$ref": "#/$defs/DownstreamTestElement"
                   },
                   {
-                    "$ref": "#/$defs/IfStatement_Union_CommandTestElement__PythonTestElement__DownstreamTestElement__"
+                    "$ref": "#/$defs/IfStatement_Union_ScriptTestElement__PythonTestElement__DownstreamTestElement__"
                   },
                   {
                     "items": {
                       "anyOf": [
                         {
-                          "$ref": "#/$defs/CommandTestElement"
+                          "$ref": "#/$defs/ScriptTestElement"
                         },
                         {
                           "$ref": "#/$defs/PythonTestElement"
@@ -1747,7 +1688,7 @@
                           "$ref": "#/$defs/DownstreamTestElement"
                         },
                         {
-                          "$ref": "#/$defs/IfStatement_Union_CommandTestElement__PythonTestElement__DownstreamTestElement__"
+                          "$ref": "#/$defs/IfStatement_Union_ScriptTestElement__PythonTestElement__DownstreamTestElement__"
                         }
                       ]
                     },
@@ -2523,6 +2464,74 @@
       "title": "RunExports",
       "type": "object"
     },
+    "ScriptTestElement": {
+      "additionalProperties": false,
+      "properties": {
+        "script": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/FileScript"
+            },
+            {
+              "$ref": "#/$defs/ContentScript"
+            },
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/IfStatement"
+            },
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/$defs/IfStatement"
+                  }
+                ]
+              },
+              "type": "array"
+            }
+          ],
+          "default": null,
+          "description": "A script to run to perform the test.",
+          "title": "Script"
+        },
+        "requirements": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TestElementRequires"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Additional dependencies to install before running the test."
+        },
+        "files": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TestElementFiles"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Additional files to include for the test."
+        }
+      },
+      "title": "ScriptTestElement",
+      "type": "object"
+    },
     "SharedLibraries": {
       "additionalProperties": false,
       "properties": {
@@ -2820,10 +2829,10 @@
           ],
           "description": "The package name and version."
         },
-        "test": {
+        "tests": {
           "anyOf": [
             {
-              "$ref": "#/$defs/CommandTestElement"
+              "$ref": "#/$defs/ScriptTestElement"
             },
             {
               "$ref": "#/$defs/PythonTestElement"
@@ -2838,7 +2847,7 @@
               "items": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/CommandTestElement"
+                    "$ref": "#/$defs/ScriptTestElement"
                   },
                   {
                     "$ref": "#/$defs/PythonTestElement"
@@ -2859,7 +2868,7 @@
           ],
           "default": null,
           "description": "Tests to run after packaging",
-          "title": "Test"
+          "title": "Tests"
         },
         "requirements": {
           "anyOf": [


### PR DESCRIPTION
Rename `test` -> `tests`


`extra_requirements` -> `requirements`

Fix up the example recipes to match the format.