### PR TITLE
Add sha256 and md5 to local path source

### DIFF
--- a/model.py
+++ b/model.py
@@ -112,6 +112,8 @@ GitSource = GitRev | GitTag | GitBranch | BaseGitSource
 
 class LocalSource(BaseSource):
     path: str = Field(..., description="A path on the local machine that contains the source.")
+    sha256: SHA256Str | None = Field(None, description="The SHA256 hash of the source archive")
+    md5: MD5Str | None = Field(None, description="The MD5 hash of the source archive")
     use_gitignore: bool = Field(
         default=True,
         description="Whether or not to use the .gitignore file when copying the source.",

--- a/schema.json
+++ b/schema.json
@@ -1778,6 +1778,38 @@
           "title": "Path",
           "type": "string"
         },
+        "sha256": {
+          "anyOf": [
+            {
+              "maxLength": 64,
+              "minLength": 64,
+              "pattern": "[a-fA-F0-9]{64}",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The SHA256 hash of the source archive",
+          "title": "Sha256"
+        },
+        "md5": {
+          "anyOf": [
+            {
+              "maxLength": 32,
+              "minLength": 32,
+              "pattern": "[a-fA-F0-9]{32}",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The MD5 hash of the source archive",
+          "title": "Md5"
+        },
         "use_gitignore": {
           "default": true,
           "description": "Whether or not to use the .gitignore file when copying the source.",


### PR DESCRIPTION
These only work if the path points to a single file (e.g. archive or file).

Not sure if we should try to figure that out with a regex?