### PR TITLE
fix: `python/imports` are optional

### DIFF
--- a/conda_recipe_v2_schema/model.py
+++ b/conda_recipe_v2_schema/model.py
@@ -470,7 +470,7 @@ class ScriptTestElement(StrictBaseModel):
 
 class PythonTestElementInner(StrictBaseModel):
     imports: ConditionalList[NonEmptyStr] = Field(
-        ...,
+        None,
         description="A list of Python imports to check after having installed the built package.",
     )
     pip_check: bool = Field(

--- a/schema.json
+++ b/schema.json
@@ -3555,6 +3555,7 @@
               "type": "array"
             }
           ],
+          "default": null,
           "description": "A list of Python imports to check after having installed the built package.",
           "title": "Imports"
         },
@@ -3584,9 +3585,6 @@
           "title": "Python Version"
         }
       },
-      "required": [
-        "imports"
-      ],
       "title": "PythonTestElementInner",
       "type": "object"
     },


### PR DESCRIPTION
The `imports` key was never required according to CEP 14 or the reference.  The current versions of rattler-build no longer force it either.

See also prefix-dev/rattler-build#2063