### PR TITLE
feat: add source filter to url and git sources

### DIFF
--- a/conda_recipe_v2_schema/model.py
+++ b/conda_recipe_v2_schema/model.py
@@ -92,6 +92,10 @@ class BaseSource(StrictBaseModel):
     target_directory: NonEmptyStr | None = Field(
         None, description="The location in the working directory to place the source"
     )
+    filter: Glob = Field(
+        None,
+        description="Glob patterns to include or exclude files from the extracted source.",
+    )
 
 
 class AttestationConfig(StrictBaseModel):
@@ -164,9 +168,6 @@ class LocalSource(BaseSource):
     file_name: NonEmptyStr | None = Field(
         None,
         description="A file name to rename the file to (does not apply to archives).",
-    )
-    filter: Glob = Field(
-        None, description="Glob patterns to include or exclude files from the package."
     )
 
 

--- a/schema.json
+++ b/schema.json
@@ -220,6 +220,37 @@
           "description": "The location in the working directory to place the source",
           "title": "Target Directory"
         },
+        "filter": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/IfStatement"
+            },
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/$defs/IfStatement"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/GlobDict"
+            }
+          ],
+          "default": null,
+          "description": "Glob patterns to include or exclude files from the extracted source.",
+          "title": "Filter"
+        },
         "git": {
           "anyOf": [
             {
@@ -1719,6 +1750,37 @@
           "description": "The location in the working directory to place the source",
           "title": "Target Directory"
         },
+        "filter": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/IfStatement"
+            },
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/$defs/IfStatement"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/GlobDict"
+            }
+          ],
+          "default": null,
+          "description": "Glob patterns to include or exclude files from the extracted source.",
+          "title": "Filter"
+        },
         "git": {
           "anyOf": [
             {
@@ -1836,6 +1898,37 @@
           "description": "The location in the working directory to place the source",
           "title": "Target Directory"
         },
+        "filter": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/IfStatement"
+            },
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/$defs/IfStatement"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/GlobDict"
+            }
+          ],
+          "default": null,
+          "description": "Glob patterns to include or exclude files from the extracted source.",
+          "title": "Filter"
+        },
         "git": {
           "anyOf": [
             {
@@ -1952,6 +2045,37 @@
           "default": null,
           "description": "The location in the working directory to place the source",
           "title": "Target Directory"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/IfStatement"
+            },
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/$defs/IfStatement"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/GlobDict"
+            }
+          ],
+          "default": null,
+          "description": "Glob patterns to include or exclude files from the extracted source.",
+          "title": "Filter"
         },
         "git": {
           "anyOf": [
@@ -2528,6 +2652,37 @@
           "description": "The location in the working directory to place the source",
           "title": "Target Directory"
         },
+        "filter": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/IfStatement"
+            },
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/$defs/IfStatement"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/GlobDict"
+            }
+          ],
+          "default": null,
+          "description": "Glob patterns to include or exclude files from the extracted source.",
+          "title": "Filter"
+        },
         "path": {
           "description": "A path on the local machine that contains the source.",
           "title": "Path",
@@ -2592,37 +2747,6 @@
           "default": null,
           "description": "A file name to rename the file to (does not apply to archives).",
           "title": "File Name"
-        },
-        "filter": {
-          "anyOf": [
-            {
-              "minLength": 1,
-              "type": "string"
-            },
-            {
-              "$ref": "#/$defs/IfStatement"
-            },
-            {
-              "items": {
-                "anyOf": [
-                  {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/$defs/IfStatement"
-                  }
-                ]
-              },
-              "type": "array"
-            },
-            {
-              "$ref": "#/$defs/GlobDict"
-            }
-          ],
-          "default": null,
-          "description": "Glob patterns to include or exclude files from the package.",
-          "title": "Filter"
         }
       },
       "required": [
@@ -4593,6 +4717,37 @@
           "default": null,
           "description": "The location in the working directory to place the source",
           "title": "Target Directory"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/IfStatement"
+            },
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/$defs/IfStatement"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/GlobDict"
+            }
+          ],
+          "default": null,
+          "description": "Glob patterns to include or exclude files from the extracted source.",
+          "title": "Filter"
         },
         "url": {
           "anyOf": [


### PR DESCRIPTION
Move the `filter` glob field from LocalSource up to BaseSource so that url, git, and path sources all support include/exclude glob filtering of the extracted source, matching prefix-dev/rattler-build#2608.