### PR TITLE
Add top-level schema fields

### DIFF
--- a/conda_recipe_v2_schema/model.py
+++ b/conda_recipe_v2_schema/model.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import json
-from typing import Annotated, Any, Generic, Literal, TypeVar, Union
+import sys
+from typing import Annotated, Any, ClassVar, Generic, Literal, TypeVar, Union
 
 from pydantic import (
     AnyHttpUrl,
@@ -13,6 +14,19 @@ from pydantic import (
     constr,
 )
 
+SCHEMA_DRAFT = "http://json-schema.org/draft-07/schema#"
+SCHEMA_URI = (
+    "https://raw.githubusercontent.com/prefix-dev/recipe-format/refs/heads/main/schema.json"
+)
+SCHEMA_HTML = "https://github.com/prefix-dev/recipe-format"
+
+SCHEMA_HEADER = {
+    "$id": SCHEMA_URI,
+    "$schema": SCHEMA_DRAFT,
+    "title": "conda recipe file",
+}
+
+
 NonEmptyStr = constr(min_length=1)
 PathNoBackslash = constr(pattern=r"^[^\\]+$")
 UnsignedInt = conint(ge=0)
@@ -21,7 +35,7 @@ JinjaExpr = constr(pattern=r"\$\{\{.*\}\}")
 
 
 class StrictBaseModel(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
 
 ###########################
@@ -704,6 +718,14 @@ SchemaVersion = Annotated[int, Field(ge=1, le=1)]
 
 
 class BaseRecipe(StrictBaseModel):
+    schema_: str | None = Field(
+        SCHEMA_URI,
+        alias="$schema",
+        title="Schema",
+        description="An identifier for the schema used to validate this recipe",
+        json_schema_extra={"format": "uri-reference"},
+    )
+
     schema_version: SchemaVersion = Field(
         1,
         description="The version of the YAML schema for a recipe. If the version is omitted it is assumed to be 1.",
@@ -771,9 +793,16 @@ class SimpleRecipe(BaseRecipe):
 Recipe = TypeAdapter(SimpleRecipe | ComplexRecipe)
 
 
-def main():
-    print(json.dumps(Recipe.json_schema(), indent=2))
+def top_level_schema() -> dict[str, Any]:
+    schema = Recipe.json_schema()
+    any_of = schema.pop("anyOf")
+    return {**SCHEMA_HEADER, "oneOf": any_of, **schema}
+
+
+def main() -> int:
+    print(json.dumps(top_level_schema(), indent=2))
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/examples/invalid/dollarschema.yaml
+++ b/examples/invalid/dollarschema.yaml
@@ -1,0 +1,1 @@
+$schema: NO

--- a/schema.json
+++ b/schema.json
@@ -1,4 +1,15 @@
 {
+  "$id": "https://raw.githubusercontent.com/prefix-dev/recipe-format/refs/heads/main/schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "conda recipe file",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/SimpleRecipe"
+    },
+    {
+      "$ref": "#/$defs/ComplexRecipe"
+    }
+  ],
   "$defs": {
     "About": {
       "additionalProperties": false,
@@ -809,6 +820,20 @@
     "ComplexRecipe": {
       "additionalProperties": false,
       "properties": {
+        "$schema": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "https://raw.githubusercontent.com/prefix-dev/recipe-format/refs/heads/main/schema.json",
+          "description": "An identifier for the schema used to validate this recipe",
+          "format": "uri-reference",
+          "title": "Schema"
+        },
         "schema_version": {
           "default": 1,
           "description": "The version of the YAML schema for a recipe. If the version is omitted it is assumed to be 1.",
@@ -4092,6 +4117,20 @@
     "SimpleRecipe": {
       "additionalProperties": false,
       "properties": {
+        "$schema": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "https://raw.githubusercontent.com/prefix-dev/recipe-format/refs/heads/main/schema.json",
+          "description": "An identifier for the schema used to validate this recipe",
+          "format": "uri-reference",
+          "title": "Schema"
+        },
         "schema_version": {
           "default": 1,
           "description": "The version of the YAML schema for a recipe. If the version is omitted it is assumed to be 1.",
@@ -4916,13 +4955,5 @@
       "title": "Variant",
       "type": "object"
     }
-  },
-  "anyOf": [
-    {
-      "$ref": "#/$defs/SimpleRecipe"
-    },
-    {
-      "$ref": "#/$defs/ComplexRecipe"
-    }
-  ]
+  }
 }

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -6,7 +6,7 @@ from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 from pydantic import ValidationError as PydanticValidationError
 
-from conda_recipe_v2_schema.model import Recipe
+from conda_recipe_v2_schema.model import Recipe, top_level_schema
 
 
 @pytest.fixture(
@@ -25,6 +25,7 @@ def valid_recipe(request) -> str:
     scope="module",
     params=[
         "complex1",
+        "dollarschema",
         "simple1",
     ],
 )
@@ -53,7 +54,7 @@ def test_recipe_schema_invalid(recipe_schema, invalid_recipe):
 
 
 def test_recipe_schema_not_changed(recipe_schema):
-    assert recipe_schema == Recipe.json_schema()
+    assert recipe_schema == top_level_schema()
 
 
 def test_patches_valid_conditional():


### PR DESCRIPTION
## References

- #29
- https://github.com/conda-forge/yaml-language-server-feedstock/pull/13

## Changes
- [x] add top-level schema fields
  - [x] `$id`
  - [x] `$schema` to declare Draft 7
  - [x] `title`
  - [x] `oneOf`
    - [x] change the top-level `anyOf` to the more accurate `oneOf`
   - [x] `$defs/*Recipe/properties/$schema`
- [x] update tests

## Motivation

Over two years since the initial PR, `yaml-language-server` has added support for locating schema from inline `$schema` instead of `#yadda-yadda: $schema` or `# $schema` (used by some _other_ tools). This would allow for more precise and machine-readable identification.

## Future Work

- Publish the schema somewhere versioned
  - my recommendation would be ReadTheDocs, as versions, and the per-PR preview site are far easier to review vs "you get exactly one" of GitHub pages
- Encourage downstream tools like `conda-recipe-manager` to populate the `$schema:` field 