### PR TITLE
use ConditionalList[NonEmptyStr] for tests/python/python_version

### DIFF
--- a/conda_recipe_v2_schema/model.py
+++ b/conda_recipe_v2_schema/model.py
@@ -499,7 +499,7 @@ class PythonTestElementInner(StrictBaseModel):
         default=True,
         description="Whether or not to run `pip check` during the Python tests.",
     )
-    python_version: str | list[str] | None = Field(
+    python_version: ConditionalList[NonEmptyStr] | None = Field(
         None,
         description="Python version(s) to test against. If not specified, the default python version is used.",
     )

--- a/schema.json
+++ b/schema.json
@@ -3579,11 +3579,23 @@
         "python_version": {
           "anyOf": [
             {
+              "minLength": 1,
               "type": "string"
             },
             {
+              "$ref": "#/$defs/IfStatement"
+            },
+            {
               "items": {
-                "type": "string"
+                "anyOf": [
+                  {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/$defs/IfStatement"
+                  }
+                ]
               },
               "type": "array"
             },


### PR DESCRIPTION
Thanks for maintaining this!

This changes `tests/python/python_version` to allow `if/then/else`(s) of non-empty strings.

This is used in the wild in at least [`py-rattler-feedstock`](https://github.com/conda-forge/py-rattler-feedstock/blob/main/recipe/recipe.yaml#L121), which may be worth considering as a test fixture.

References:
- fixes #84 